### PR TITLE
Add autocapitalization configuration to VBaseTextField and VTextField

### DIFF
--- a/VComponents/Components/Inputs/VBaseTextField/UIKitTextFieldRepresentable.swift
+++ b/VComponents/Components/Inputs/VBaseTextField/UIKitTextFieldRepresentable.swift
@@ -95,6 +95,10 @@ extension UIKitTextFieldRepresentable: UIViewRepresentable {
         textField.autocorrectionType = model.misc.autoCorrect
         if autocorrectChanged { textField.reloadInputViews() }
         
+        let autocapitalizationChanged: Bool = textField.autocapitalizationType != model.misc.autoCapitalization
+        textField.autocapitalizationType = model.misc.autoCapitalization
+        if autocapitalizationChanged { textField.reloadInputViews() }
+        
         textField.textAlignment = model.layout.textAlignment.nsTextAlignment
         
         textField.placeholder = placeholder

--- a/VComponents/Components/Inputs/VBaseTextField/VBaseTextFieldModel.swift
+++ b/VComponents/Components/Inputs/VBaseTextField/VBaseTextFieldModel.swift
@@ -119,6 +119,9 @@ extension VBaseTextFieldModel {
         /// Auto correct type. Defaults to `default`.
         public var autoCorrect: UITextAutocorrectionType = .default
         
+        /// Auto capitalization type. Defaults to `sentence`.
+        public var autoCapitalization: UITextAutocapitalizationType = .sentences
+        
         /// Default button type. Defaults to `default`.
         public var returnButton: UIReturnKeyType = .default
         

--- a/VComponents/Components/Inputs/VTextField/VTextFieldModel.swift
+++ b/VComponents/Components/Inputs/VTextField/VTextFieldModel.swift
@@ -268,6 +268,9 @@ extension VTextFieldModel {
         /// Auto correct type. Defaults to `default`.
         public var autoCorrect: UITextAutocorrectionType = baseTextFieldReference.misc.autoCorrect
         
+        /// Auto capitalization type. Defaults to `sentence`.
+        public var autoCapitalization: UITextAutocapitalizationType = baseTextFieldReference.misc.autoCapitalization
+        
         /// Default button type. Defaults to `default`.
         public var returnButton: UIReturnKeyType = baseTextFieldReference.misc.returnButton
         
@@ -324,7 +327,8 @@ extension VTextFieldModel {
         
         model.misc.spellCheck = misc.spellCheck
         model.misc.autoCorrect = misc.autoCorrect
-        
+        model.misc.autoCapitalization = misc.autoCapitalization
+
         model.misc.returnButton = misc.returnButton
         
         return model

--- a/VComponentsDemo/Views/Demos/Inputs/VBaseTextFieldDemoView.swift
+++ b/VComponentsDemo/Views/Demos/Inputs/VBaseTextFieldDemoView.swift
@@ -20,7 +20,8 @@ struct VBaseTextFieldDemoView: View {
     @State private var textAlignment: VBaseTextFieldModel.Layout.TextAlignment = .default
     @State private var spellCheck: UITextSpellCheckingType = VBaseTextFieldModel.Misc().spellCheck
     @State private var autoCorrect: UITextAutocorrectionType = VBaseTextFieldModel.Misc().autoCorrect
-    
+    @State private var autoCapitalizaton: UITextAutocapitalizationType = VTextFieldModel.Misc().autoCapitalization
+
     private var model: VBaseTextFieldModel {
         var model: VBaseTextFieldModel = .init()
         
@@ -29,6 +30,7 @@ struct VBaseTextFieldDemoView: View {
         model.misc.keyboardType = numericalKeyboard ? .numberPad : .default
         model.misc.spellCheck = spellCheck
         model.misc.autoCorrect = autoCorrect
+        model.misc.autoCapitalization = autoCapitalizaton
         
         return model
     }
@@ -81,10 +83,12 @@ extension VBaseTextFieldDemoView {
                     title: "Content Type",
                     description: "Default set to \"nil\". Other types are not shown in the demo, as there are many."
                 )
-                
+                                
                 VSegmentedPicker(selection: $spellCheck, headerTitle: "Spell Check")
 
                 VSegmentedPicker(selection: $autoCorrect, headerTitle: "Autocorrect")
+                
+                VSegmentedPicker(selection: $autoCapitalizaton, headerTitle: "Autocapitalizaton")
 
                 VSegmentedPicker(selection: $textAlignment, headerTitle: "Alignment")
             })
@@ -137,6 +141,20 @@ extension UITextAutocorrectionType: VPickableTitledItem {
         case .no: return "No"
         case .yes: return "Yes"
         case .default: return "Auto"
+        @unknown default: return ""
+        }
+    }
+}
+
+extension UITextAutocapitalizationType: VPickableTitledItem {
+    public static var allCases: [Self] = [.none, .sentences, .words, .allCharacters]
+    
+    public var pickerTitle: String {
+        switch self {
+        case .none: return "None"
+        case .sentences: return "Sentences"
+        case .words: return "Words"
+        case .allCharacters: return "Caps Lock"
         @unknown default: return ""
         }
     }

--- a/VComponentsDemo/Views/Demos/Inputs/VTextFieldDemoView.swift
+++ b/VComponentsDemo/Views/Demos/Inputs/VTextFieldDemoView.swift
@@ -24,6 +24,7 @@ struct VTextFieldDemoView: View {
     @State private var textAlignment: VTextFieldModel.Layout.TextAlignment = .default
     @State private var spellCheck: UITextSpellCheckingType = VTextFieldModel.Misc().spellCheck
     @State private var autoCorrect: UITextAutocorrectionType = VTextFieldModel.Misc().autoCorrect
+    @State private var autoCapitalizaton: UITextAutocapitalizationType = VTextFieldModel.Misc().autoCapitalization
     @State private var hasClearButton: Bool = VTextFieldModel.Misc().clearButton
     @State private var hasCancelButton: Bool = VTextFieldModel.Misc().cancelButton != nil
     
@@ -36,6 +37,7 @@ struct VTextFieldDemoView: View {
         
         model.misc.spellCheck = spellCheck
         model.misc.autoCorrect = autoCorrect
+        model.misc.autoCapitalization = autoCapitalizaton
         
         model.misc.clearButton = hasClearButton
         model.misc.cancelButton = hasCancelButton ? "Cancel" : nil
@@ -122,6 +124,8 @@ extension VTextFieldDemoView {
 
                 VSegmentedPicker(selection: $autoCorrect, headerTitle: "Autocorrect")
 
+                VSegmentedPicker(selection: $autoCapitalizaton, headerTitle: "Autocapitalizaiton")
+                
                 VSegmentedPicker(selection: $textAlignment, headerTitle: "Alignment")
             })
         })


### PR DESCRIPTION
Added to the models autoCapitalization: UITextAutocapitalizationType. Also updated demo. Autocapitalization is defaulted to .sentence.